### PR TITLE
Fix shutdown()

### DIFF
--- a/addon/bootstrap.js
+++ b/addon/bootstrap.js
@@ -25,6 +25,8 @@ function shutdown(data, reason) {
         return;
     }
 
+    var { TBKeys } = ChromeUtils.import("chrome://tbkeys/content/tbkeys.js");
+
     TBKeys.cleanup();
     Cu.unload("chrome://tbkeys/content/tbkeys.js");
 }


### PR DESCRIPTION
shutdown() currently crashes because TBKeys is not imported in that
scope. This is quite inconvenient, especially as it prevents the addon
from being reloaded without restarting Thunderbird. Fix it by importing
TBKeys like in startup().