### PR TITLE
Add TB 78 textboxes to ignore list

### DIFF
--- a/addon/implementation.js
+++ b/addon/implementation.js
@@ -81,6 +81,7 @@ var TBKeys = {
             return (
                 tagName == 'textbox' || tagName == 'input' ||
                 tagName == 'select' || tagName == 'textarea' ||
+                tagName == 'html:input' || tagName == 'search-textbox' ||
                 (element.contentEditable && element.contentEditable == 'true')
             )
         }

--- a/addon/manifest.json
+++ b/addon/manifest.json
@@ -10,7 +10,7 @@
   "name": "tbkeys",
   "description": "Custom Thunderbird keybindings",
   "author": "Will Shanks",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "background": {
     "scripts": ["background.js"]
   },

--- a/updates.json
+++ b/updates.json
@@ -16,6 +16,10 @@
         {
           "version": "2.0.1",
           "update_link": "https://github.com/willsALMANJ/tbkeys/releases/download/v2.0.1/tbkeys.xpi"
+        },
+        {
+          "version": "2.0.2",
+          "update_link": "https://github.com/willsALMANJ/tbkeys/releases/download/v2.0.2/tbkeys.xpi"
         }
       ]
     }


### PR DESCRIPTION
Closes #17. Thunderbird 78 changed the tag names associated with some of the textboxes in its UI. This PR prevents capturing key events in the elements I found by testing a bunch at random. There could be other tag names I missed.