### PR TITLE
Change double quotes to single quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,10 +40,12 @@ The preferences page will not allow invalid JSON to be submitted, but it does no
 
 Here are some commonly desired keybindings:
 
-* **Next tab**: `window.document.getElementById("tabmail-tabs").advanceSelectedTabs(1, true)`
-* **Previous tab**: `window.document.getElementById("tabmail-tabs").advanceSelectedTabs(-1, true)`
+* **Next tab**: `window.document.getElementById('tabmail-tabs').advanceSelectedTabs(1, true)`
+* **Previous tab**: `window.document.getElementById('tabmail-tabs').advanceSelectedTabs(-1, true)`
 * **Close tab**: `window.document.getElementById('tabmail-tabs').selectedItem.getElementsByClassName('tab-close-button')[0].click()`
-* **Scroll message list**: `window.document.getElementById('threadTree').scrollByLines(1)`
-* **Scroll message body**: `window.document.getElementById("messagepane").contentDocument.documentElement.getElementsByTagName("body")[0].scrollBy(0, 100)`
+* **Scroll message list down**: `window.document.getElementById('threadTree').scrollByLines(1)`
+* **Scroll message list up**: `window.document.getElementById('threadTree').scrollByLines(-1)`
+* **Scroll message body down**: `window.document.getElementById('messagepane').contentDocument.documentElement.getElementsByTagName('body')[0].scrollBy(0, 100)`
+* **Scroll message body up**: `window.document.getElementById('messagepane').contentDocument.documentElement.getElementsByTagName('body')[0].scrollBy(0, -100)`
 * **Create new folder**: `goDoCommand('cmd_newFolder')`
 * **Subscribe to feed**: `window.openSubscriptionsDialog(window.GetSelectedMsgFolders()[0])`


### PR DESCRIPTION
Change the double quotes around `("body")`, `("messagepane")`, etc., to single quotes `('body')`, `('messagepane')`, etc., because the whole command will often be enclosed in double quotes, and double quotes within double quotes doesn't work.  Also, add scroll up/down examples.